### PR TITLE
fixed 'temporary value dropped while borrowed' error

### DIFF
--- a/src/show_color.rs
+++ b/src/show_color.rs
@@ -46,7 +46,7 @@ fn show_impl(rgb: space::Rgb, msg: String, json: String) -> Result<()> {
         queue!(
             stdout,
             SetForegroundColor(crossterm_color),
-            Print(&make_square(4)),
+            Print(make_square(4)),
             ResetColor,
         )?;
     } else {


### PR DESCRIPTION
Just removed an un-needed borrow that was causing a compilation error for me.