### PR TITLE
Bump `color_space` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "color_space"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b3d592a78ccb0ed9cca347edc73d39446b1267f4e2adc5884aa52190dda267"
+checksum = "3776b2bcc4e914db501bb9be9572dd706e344b9eb8f882894f3daa651d281381"
 
 [[package]]
 name = "crossterm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["color", "cli"]
 license = "MIT"
 
 [dependencies]
-crossterm = "0.18.1" 
-clap = "2" 
-color_space = "=0.5.2" # TODO: This version has a few bugs for which I have hacky workarounds. Fix the bugs upstream, then update this dep and remove the workarounds
+crossterm = "0.18.1"
+clap = "2"
+color_space = "^0.5.3"
 anyhow = "1"

--- a/src/color/html.rs
+++ b/src/color/html.rs
@@ -1,5 +1,7 @@
 use super::space::Rgb;
 
+/// List of HTML color, taken from
+/// https://www.w3schools.com/colors/colors_groups.asp
 const HTML_COLOR_NAMES: &[(&str, u32)] = &[
     ("pink", 0xffc0cb),
     ("lightpink", 0xffb6c1),
@@ -145,21 +147,12 @@ const HTML_COLOR_NAMES: &[(&str, u32)] = &[
 ];
 
 /// Gets an HTML color. The name (e.g. `Rebeccapurple`) is converted to lowercase first.
-/// If this function is called many times, it's more efficient to use the `HtmlColors` struct.
+/// If this function is called many times, it's more efficient to build a HashMap.
 pub fn get(name: &str) -> Option<Rgb> {
     let name = name.to_lowercase();
     HTML_COLOR_NAMES
         .iter()
         .filter(|&&(k, _)| k == name)
-        .map(|&(_, hex)| from_hex(hex))
+        .map(|&(_, hex)| Rgb::from_hex(hex))
         .next()
-}
-
-fn from_hex(hex: u32) -> Rgb {
-    // TODO: Fix `Rgb::from_hex` upstream, so it can be used here
-    Rgb {
-        r: ((hex >> 16) & 0xff) as f64,
-        g: ((hex >> 8) & 0xff) as f64,
-        b: (hex & 0xff) as f64,
-    }
 }

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -61,12 +61,7 @@ impl Color {
             ColorSpace::Cmy => Color::Cmy(Cmy::from_rgb(&rgb)),
             ColorSpace::Cmyk => Color::Cmyk(Cmyk::from_rgb(&rgb)),
             ColorSpace::Hsv => Color::Hsv(Hsv::from_rgb(&rgb)),
-            ColorSpace::Hsl => Color::Hsl(Hsl::from_rgb(&Rgb {
-                // TODO: fix this upstream
-                r: rgb.r / 255.0,
-                g: rgb.g / 255.0,
-                b: rgb.b / 255.0,
-            })),
+            ColorSpace::Hsl => Color::Hsl(Hsl::from_rgb(&rgb)),
             ColorSpace::Lch => Color::Lch(Lch::from_rgb(&rgb)),
             ColorSpace::Luv => Color::Luv(Luv::from_rgb(&rgb)),
             ColorSpace::Lab => Color::Lab(Lab::from_rgb(&rgb)),


### PR DESCRIPTION
This removes the need for workarounds which now have been implemented upstream. See [this issue](https://github.com/ChevyRay/color_space/issues/5).