### PR TITLE
Add `list` subcommand

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+use clap::{App, ArgMatches, SubCommand};
+
+/// Returns the `list` subcommand
+pub fn command<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("list")
+        .about("Lists all HTML colors")
+        .version(super::APP_VERSION)
+}
+
+/// The struct representing the `list` subcommand
+pub struct List;
+
+/// Return the input for the `libs` subcommand
+pub fn get(_matches: &ArgMatches) -> Result<List> {
+    Ok(List)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,12 +1,14 @@
 use clap::{App, AppSettings};
 
 mod libs;
+mod list;
 mod print;
 mod show;
 mod term;
 mod util;
 
 pub use libs::{get as get_libs, Libs};
+pub use list::{get as get_list, List};
 pub use print::{get as get_print, Print};
 pub use show::{get as get_show, Show};
 pub use term::{get as get_term, Term};
@@ -89,6 +91,7 @@ pub fn app<'a, 'b>() -> App<'a, 'b> {
         .subcommand(term::command())
         .subcommand(libs::command())
         .subcommand(print::command())
+        .subcommand(list::command())
         .subcommand(show::command())
         .set_term_width(80)
 }

--- a/src/color/html.rs
+++ b/src/color/html.rs
@@ -1,4 +1,11 @@
-use super::{hex, space::Rgb};
+use std::io::{stdout, Write};
+
+use super::{
+    hex,
+    space::{self, Rgb},
+};
+use anyhow::Result;
+use colored::{Color::TrueColor, Colorize};
 
 /// List of HTML color, taken from
 /// https://www.w3schools.com/colors/colors_groups.asp
@@ -190,4 +197,41 @@ pub fn get_name(color: Rgb) -> Option<&'static str> {
         .filter(|&&(_, v)| v == hex)
         .map(|&(name, _)| name)
         .next()
+}
+
+pub fn show_all() -> Result<()> {
+    let mut stdout = stdout();
+
+    let mut even = false;
+
+    for &(name, color) in HTML_COLOR_NAMES {
+        if name == "magenta" || name == "aqua" || name.ends_with("grey") {
+            continue;
+        }
+        let color = Rgb::from_hex(color);
+        let hsl: space::Hsl = color.into();
+        let color = TrueColor {
+            r: color.r as u8,
+            g: color.g as u8,
+            b: color.b as u8,
+        };
+        let text_color = if hsl.l < 0.5 {
+            TrueColor {
+                r: 255,
+                g: 255,
+                b: 255,
+            }
+        } else {
+            TrueColor { r: 0, g: 0, b: 0 }
+        };
+        let name = format!("   {}{}", name, &"                     "[name.len()..]);
+        write!(stdout, "{}", name.color(text_color).on_color(color))?;
+        if even {
+            writeln!(stdout)?;
+        }
+        even = !even;
+    }
+    writeln!(stdout)?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_code)]
 
 use anyhow::Result;
+use color::html;
 use color_space::ToRgb;
 
 mod cli;
@@ -58,6 +59,11 @@ fn main() -> Result<()> {
             for (color, input) in colors {
                 show_color::show(color, input, output, size)?;
             }
+        }
+        ("list", Some(matches)) => {
+            let cli::List = cli::get_list(&matches)?;
+
+            html::show_all()?;
         }
         _ => {
             cli::app().print_help().unwrap();


### PR DESCRIPTION
The `list` subcommand shows all HTML colors (except fuchsia and aqua, which are the same colors as magenta and cyan).