### PR TITLE
Fix bug displaying hex colors, improve text color

### DIFF
--- a/Color spaces.md
+++ b/Color spaces.md
@@ -3,7 +3,7 @@
 Color spaces are reproducible representations of color. Most color spaces have three dimensions that describe properties of the color (such as color hue, saturation, luminance), or their composition of primary colors, using a certain [color model](https://en.wikipedia.org/wiki/Color_model).
 
 
-## sRGB
+## RGB (sRGB)
 
 [sRGB](https://en.wikipedia.org/wiki/SRGB) (often simply called _RGB_) is a color space of the three primary colors **red**, **green** and **blue**. It uses additive color mixing, which is how colored light works. The sRGB color space is therefore used by computer screens, for example.
 
@@ -81,7 +81,7 @@ Saturation and lightness are values between 0 and 1 (or 100%). When the lightnes
 
 ## HSV
 
-[HSV](https://en.wikipedia.org/wiki/HSL_and_HSV) is also a color space designed to be intuitive to understand. It consists of **hue**, **saturation** and **value**. The hue is the same as in the HSL model.
+[HSV](https://en.wikipedia.org/wiki/HSL_and_HSV) is also a color space designed to be intuitive to understand. It consists of **hue**, **saturation** and **value**. The hue is the same as in the HSL model. Hue and saturation together describe the [chromaticity](https://en.wikipedia.org/wiki/Chromaticity).
 
 Saturation and value are again values between 0 and 1. When the value is 0, the color is full black. When the value is 1, the color depends on the hue and saturation.
 
@@ -96,11 +96,20 @@ Saturation and value are again values between 0 and 1. When the value is 0, the 
 | `hsv(240, 1, 1)` | ![color](docs/colors/blue.png)
 | `hsv(300, 1, 1)` | ![color](docs/colors/magenta.png)
 
-## LCH
 
-## LUV
+## LAB (CIELAB)
 
-## LAB
+[CIELAB](https://en.wikipedia.org/wiki/CIELAB_color_space) is a color space consisting of three values: __L\*__ for the lightness from black (0) to white (100), __a\*__ from green (−) to red (+), and __b\*__ from blue (−) to yellow (+). It was designed so that the same amount of numerical change in these values corresponds to roughly the same amount of visually perceived change. __a\*__ and __b\*__ together describe the [chromaticity](https://en.wikipedia.org/wiki/Chromaticity) (hue and colorfulness).
+
+CIELAB is designed to approximate human vision. It's __L\*__ component closely matches human perception of lightness.
+
+## LCH (CIELCh)
+
+[CIELCh](https://en.wikipedia.org/wiki/CIELAB_color_space#Cylindrical_representation:_CIELCh_or_CIEHLC)
+
+## LUV (CIELUV)
+
+[CIELUV](https://en.wikipedia.org/wiki/CIELUV)
 
 ## Hunter Lab
 

--- a/src/color/hex.rs
+++ b/src/color/hex.rs
@@ -108,7 +108,10 @@ fn scale_down(r: f64, g: f64, b: f64, len: usize) -> space::Rgb {
 
 /// Converts an RGB color to hexadecimal notation
 pub fn rgb_to_u32(rgb: space::Rgb) -> u32 {
-    ((rgb.r.round() as u32) << 16) + ((rgb.g.round() as u32) << 8) + rgb.b.round() as u32
+    let r = rgb.r.min(255.0).max(0.0).round() as u32;
+    let g = rgb.g.min(255.0).max(0.0).round() as u32;
+    let b = rgb.b.min(255.0).max(0.0).round() as u32;
+    (r << 16) + (g << 8) + b
 }
 
 #[cfg(test)]

--- a/src/color/html.rs
+++ b/src/color/html.rs
@@ -209,13 +209,17 @@ pub fn show_all() -> Result<()> {
             continue;
         }
         let color = Rgb::from_hex(color);
-        let hsl: space::Hsl = color.into();
+        let lab: space::Lab = color.into();
+
         let color = TrueColor {
             r: color.r as u8,
             g: color.g as u8,
             b: color.b as u8,
         };
-        let text_color = if hsl.l < 0.5 {
+
+        let lab_distance = (lab.a.abs().powi(2) + lab.b.abs().powi(2)).sqrt();
+        let colorfulness = lab_distance.min(100.0) / 12.0; // empirically determined values
+        let text_color = if lab.l < (60.0 - colorfulness) {
             TrueColor {
                 r: 255,
                 g: 255,
@@ -224,7 +228,7 @@ pub fn show_all() -> Result<()> {
         } else {
             TrueColor { r: 0, g: 0, b: 0 }
         };
-        let name = format!("   {}{}", name, &"                     "[name.len()..]);
+        let name = format!(" {}{}", name, &"                      "[name.len()..]);
         write!(stdout, "{}", name.color(text_color).on_color(color))?;
         if even {
             writeln!(stdout)?;


### PR DESCRIPTION
When an RGB color channel is not in the [0, 255] interval, the hexadecimal format was incorrect until now.

The text color (black or white) used on top of an arbitrary color is now computed using the [CIELAB](https://en.wikipedia.org/wiki/CIELAB_color_space) lightness, with a bias to prefer white text when the background has little [colorfulness](https://en.wikipedia.org/wiki/Colorfulness), which should compensate for the [Helmholtz–Kohlrausch effect](https://en.wikipedia.org/wiki/Helmholtz%E2%80%93Kohlrausch_effect).