### PR TITLE
Support pipes

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,20 +33,11 @@ const COLOR_FORMATS: &[&str] = &[
     "hex",
 ];
 
-const COLOR_HELP_MESSAGE: &str = "\
-The input colors. Multiple colors can be specified. Supported formats:
-
-* HTML color name, e.g. 'rebeccapurple'
-* Hexadecimal RGB color, e.g. '07F', '0077FF'
-* Color components, e.g. 'hsl(30, 100%, 50%)'
-  Commas and parentheses are optional.
-  For supported color spaces, see <https://aloso.github.io/colo/color_spaces>";
-
 /// Returns the command line arguments parsed by clap.
 ///
 /// Note that, if the `--version` or `--help` flag was provided,
 /// clap terminates the application, so this function never returns.
-pub fn app<'a, 'b>() -> App<'a, 'b> {
+pub fn app<'a, 'b>(interactive: bool) -> App<'a, 'b> {
     App::new(APP_NAME)
         .global_setting(AppSettings::ColorAuto)
         .global_setting(AppSettings::ColoredHelp)
@@ -55,8 +46,8 @@ pub fn app<'a, 'b>() -> App<'a, 'b> {
         .about("Displays colors in various color spaces.")
         .subcommand(term::command())
         .subcommand(libs::command())
-        .subcommand(print::command())
+        .subcommand(print::command(interactive))
         .subcommand(list::command())
-        .subcommand(show::command())
+        .subcommand(show::command(interactive))
         .set_term_width(80)
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,17 +1,11 @@
 use clap::{App, AppSettings};
 
-mod libs;
-mod list;
-mod print;
-mod show;
-mod term;
+pub mod libs;
+pub mod list;
+pub mod print;
+pub mod show;
+pub mod term;
 mod util;
-
-pub use libs::{get as get_libs, Libs};
-pub use list::{get as get_list, List};
-pub use print::{get as get_print, Print};
-pub use show::{get as get_show, Show};
-pub use term::{get as get_term, Term};
 
 /// Name of the program
 pub const APP_NAME: &str = env!("CARGO_PKG_NAME");

--- a/src/cli/print.rs
+++ b/src/cli/print.rs
@@ -1,11 +1,13 @@
-use anyhow::{bail, Result};
+use std::iter;
+
+use anyhow::{bail, Context, Result};
 use clap::{App, Arg, ArgMatches, SubCommand};
 
 use super::util;
 use crate::color::{Color, ColorFormat};
 
 const COLOR_HELP: &str = "\
-The input colors. Multiple colors can be separated with a comma. Supported formats:
+The input colors. You can specify up to 2 colors (text and background color). Supported formats:
 
 * HTML color name (e.g. 'rebeccapurple')
 * Hexadecimal RGB color (e.g. '07F', '0077FF')
@@ -15,27 +17,37 @@ The input colors. Multiple colors can be separated with a comma. Supported forma
 ";
 
 /// Returns the `print` subcommand
-pub fn command<'a, 'b>() -> App<'a, 'b> {
+pub fn command<'a, 'b>(interactive: bool) -> App<'a, 'b> {
     SubCommand::with_name("print")
         .about("Print formatted text")
         .version(super::APP_VERSION)
+        .usage(
+            "colo print [FLAGS] <TEXT> <COLOR>...\
+            \n    echo <TEXT> | colo print [FLAGS] <COLOR>...",
+        )
         .args(&[
+            Arg::with_name("TEXT")
+                .index(1)
+                .help(
+                    "Text to print in the specified color. If colo is \
+                    used behind a pipe or outside of the terminal, \
+                    the text must be passed via stdin instead, e.g.\n\n\
+                    $ echo Hello world! | colo print orange\n ",
+                )
+                .required(interactive),
             Arg::with_name("COLOR")
                 .index(2)
                 .help(COLOR_HELP)
                 .multiple(true)
                 .use_delimiter(false)
-                .required(true),
-            Arg::with_name("TEXT")
-                .index(1)
-                .help("Text to print in the specified color")
-                .required(true),
+                .required(interactive),
             Arg::with_name("BOLD")
                 .long("bold")
                 .short("b")
                 .help("Print text in bold"),
             Arg::with_name("ITALIC")
                 .long("italic")
+                .alias("oblique")
                 .short("i")
                 .help("Print text in italic"),
             Arg::with_name("UNDERLINE")
@@ -43,7 +55,8 @@ pub fn command<'a, 'b>() -> App<'a, 'b> {
                 .short("u")
                 .help("Print text underlined"),
             Arg::with_name("NO_NEWLINE")
-                .long("no_newline")
+                .long("no-newline")
+                .alias("no_newline")
                 .short("n")
                 .help("Don't add new-line after text"),
         ])
@@ -61,14 +74,32 @@ pub struct Print {
 }
 
 /// Returns the input for the `print` subcommand
-pub fn get(matches: &ArgMatches) -> Result<Print> {
-    let text = matches
-        .value_of("TEXT")
-        .expect("text not present")
-        .to_string();
+pub fn get(matches: &ArgMatches, interactive: bool) -> Result<Print> {
+    let (colors, text) = if interactive {
+        let text = matches
+            .value_of("TEXT")
+            .expect("text not present")
+            .to_string();
 
-    let color_matches = matches.values_of("COLOR").expect("color not present");
-    let colors = util::values_to_colors(color_matches)?;
+        let color_matches = matches.values_of("COLOR").expect("color not present");
+        let colors = util::values_to_colors(color_matches)?;
+        (colors, text)
+    } else {
+        let text = util::read_stdin()?;
+
+        // in non-interactive mode, the TEXT argument is actually the first color.
+        let arg1 = matches.value_of("TEXT").context(
+            "The following required arguments were not provided:\
+            \n    <COLOR>...\n\n\
+            USAGE:\
+            \n    echo <TEXT> | colo print [FLAGS] <COLOR>...\n\n\
+            For more information try --help",
+        )?;
+        let remaining_args = matches.values_of("COLOR").unwrap_or_default();
+        let colors = util::values_to_colors(iter::once(arg1).chain(remaining_args))?;
+
+        (colors, text)
+    };
 
     if colors.len() > 2 {
         bail!("At most two colors (text and background color) can be specified.")

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -83,7 +83,7 @@ pub fn get(matches: &ArgMatches, interactive: bool) -> Result<Show> {
     let output = util::get_color_format(&matches, "OUTPUT_FORMAT")?
         .or_else(|| {
             if colors.len() == 1 {
-                Some(colors[0].1)
+                Some(colors[0].1).filter(|&c| c != ColorFormat::Html)
             } else {
                 None
             }

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -1,6 +1,6 @@
 use anyhow::{Error, Result};
-use clap::{ArgMatches, Values};
-use std::iter;
+use clap::ArgMatches;
+use std::{io::Read, iter};
 
 use crate::color::{self, Color, ColorFormat, ParseError};
 
@@ -18,9 +18,21 @@ pub(super) fn get_color_format(
         .transpose()?)
 }
 
-pub(super) fn values_to_colors(values: Values) -> Result<Vec<(Color, ColorFormat)>, ParseError> {
+pub(super) fn values_to_colors<'a>(
+    values: impl Iterator<Item = &'a str>,
+) -> Result<Vec<(Color, ColorFormat)>, ParseError> {
     let color_input: String = values
         .flat_map(|s| iter::once(s).chain(iter::once(" ")))
         .collect();
     color::parse(&color_input)
+}
+
+pub(super) fn read_stdin() -> Result<String> {
+    let mut text = Vec::new();
+    std::io::stdin().read_to_end(&mut text)?;
+    let mut text = String::from_utf8(text)?;
+    if text.ends_with('\n') {
+        text.truncate(text.len() - 1);
+    }
+    Ok(text)
 }

--- a/src/color/html.rs
+++ b/src/color/html.rs
@@ -1,15 +1,8 @@
-use std::io::{stdout, Write};
-
-use super::{
-    hex,
-    space::{self, Rgb},
-};
-use anyhow::Result;
-use colored::{Color::TrueColor, Colorize};
+use super::{hex, space::Rgb};
 
 /// List of HTML color, taken from
 /// https://www.w3schools.com/colors/colors_groups.asp
-const HTML_COLOR_NAMES: &[(&str, u32)] = &[
+pub const HTML_COLOR_NAMES: &[(&str, u32)] = &[
     ("pink", 0xffc0cb),
     ("lightpink", 0xffb6c1),
     ("hotpink", 0xff69b4),
@@ -197,45 +190,4 @@ pub fn get_name(color: Rgb) -> Option<&'static str> {
         .filter(|&&(_, v)| v == hex)
         .map(|&(name, _)| name)
         .next()
-}
-
-pub fn show_all() -> Result<()> {
-    let mut stdout = stdout();
-
-    let mut even = false;
-
-    for &(name, color) in HTML_COLOR_NAMES {
-        if name == "magenta" || name == "aqua" || name.ends_with("grey") {
-            continue;
-        }
-        let color = Rgb::from_hex(color);
-        let lab: space::Lab = color.into();
-
-        let color = TrueColor {
-            r: color.r as u8,
-            g: color.g as u8,
-            b: color.b as u8,
-        };
-
-        let lab_distance = (lab.a.abs().powi(2) + lab.b.abs().powi(2)).sqrt();
-        let colorfulness = lab_distance.min(100.0) / 12.0; // empirically determined values
-        let text_color = if lab.l < (60.0 - colorfulness) {
-            TrueColor {
-                r: 255,
-                g: 255,
-                b: 255,
-            }
-        } else {
-            TrueColor { r: 0, g: 0, b: 0 }
-        };
-        let name = format!(" {}{}", name, &"                      "[name.len()..]);
-        write!(stdout, "{}", name.color(text_color).on_color(color))?;
-        if even {
-            writeln!(stdout)?;
-        }
-        even = !even;
-    }
-    writeln!(stdout)?;
-
-    Ok(())
 }

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -112,6 +112,23 @@ impl Color {
             ColorSpace::Yxy => Color::Yxy(Yxy::from_rgb(&rgb)),
         }
     }
+
+    pub fn to_term_color(&self) -> colored::Color {
+        let Rgb { r, g, b } = Self::clamp_rgb(self.to_rgb());
+        colored::Color::TrueColor {
+            r: r.round() as u8,
+            g: g.round() as u8,
+            b: b.round() as u8,
+        }
+    }
+
+    fn clamp_rgb(rgb: Rgb) -> Rgb {
+        Rgb {
+            r: rgb.r.min(255.0).max(0.0),
+            g: rgb.g.min(255.0).max(0.0),
+            b: rgb.b.min(255.0).max(0.0),
+        }
+    }
 }
 
 impl fmt::Display for Color {

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -122,6 +122,22 @@ impl Color {
         }
     }
 
+    pub fn text_color(&self) -> TextColor {
+        let lab = match self.to_color_space(ColorSpace::Lab) {
+            Color::Lab(lab) => lab,
+            _ => unreachable!("Conversion to Lab unsuccessful"),
+        };
+
+        let lab_distance = (lab.a.abs().powi(2) + lab.b.abs().powi(2)).sqrt();
+        let colorfulness = lab_distance.min(100.0) / 12.0; // empirically determined values
+
+        if lab.l < (60.0 - colorfulness) {
+            TextColor::White
+        } else {
+            TextColor::Black
+        }
+    }
+
     fn clamp_rgb(rgb: Rgb) -> Rgb {
         Rgb {
             r: rgb.r.min(255.0).max(0.0),
@@ -129,6 +145,12 @@ impl Color {
             b: rgb.b.min(255.0).max(0.0),
         }
     }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum TextColor {
+    Black,
+    White,
 }
 
 impl fmt::Display for Color {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,7 @@ use color_space::ToRgb;
 
 mod cli;
 mod color;
-mod show_color;
-mod show_term_colors;
+mod output;
 
 /// Entry point for the application.
 ///
@@ -24,7 +23,7 @@ fn main() -> Result<()> {
         }
         ("term", Some(matches)) => {
             let cli::Term = cli::get_term(matches)?;
-            show_term_colors::show_term_colors()?;
+            output::term::term()?;
         }
         ("print", Some(matches)) => {
             let cli::Print {
@@ -40,7 +39,7 @@ fn main() -> Result<()> {
             if !no_newline {
                 text.push('\n');
             }
-            show_color::show_text(
+            output::print::print(
                 color.to_rgb(),
                 bg_color.map(|(c, _)| c.to_rgb()),
                 text,
@@ -57,7 +56,7 @@ fn main() -> Result<()> {
             } = cli::get_show(&matches)?;
 
             for (color, input) in colors {
-                show_color::show(color, input, output, size)?;
+                output::show::show(color, input, output, size)?;
             }
         }
         ("list", Some(matches)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_code)]
 
 use anyhow::Result;
+use atty::Stream;
 
 mod cli;
 mod color;
@@ -12,7 +13,9 @@ mod output;
 /// recoverable and simply need to be reported. Rusts runtime handles this
 /// automatically, when an error is returned from `main()`.
 fn main() -> Result<()> {
-    match cli::app().get_matches().subcommand() {
+    let interactive = atty::is(Stream::Stdin);
+
+    match cli::app(interactive).get_matches().subcommand() {
         ("libs", Some(matches)) => {
             output::libs::libs(cli::libs::get(&matches)?);
         }
@@ -20,16 +23,16 @@ fn main() -> Result<()> {
             output::term::term(cli::term::get(matches)?)?;
         }
         ("print", Some(matches)) => {
-            output::print::print(cli::print::get(matches)?)?;
+            output::print::print(cli::print::get(matches, interactive)?)?;
         }
         ("show", Some(matches)) => {
-            output::show::show(cli::show::get(&matches)?)?;
+            output::show::show(cli::show::get(&matches, interactive)?)?;
         }
         ("list", Some(matches)) => {
             output::list::list(cli::list::get(&matches)?)?;
         }
         _ => {
-            cli::app().print_help().unwrap();
+            cli::app(interactive).print_help().unwrap();
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 #![deny(unsafe_code)]
 
 use anyhow::Result;
-use color::html;
-use color_space::ToRgb;
 
 mod cli;
 mod color;
@@ -14,56 +12,21 @@ mod output;
 /// recoverable and simply need to be reported. Rusts runtime handles this
 /// automatically, when an error is returned from `main()`.
 fn main() -> Result<()> {
-    let app = cli::app();
-    match app.get_matches().subcommand() {
+    match cli::app().get_matches().subcommand() {
         ("libs", Some(matches)) => {
-            use cli::{APP_NAME, APP_VERSION, DEPENDENCIES};
-            let cli::Libs = cli::get_libs(&matches)?;
-            println!("{} v{}\n{}", APP_NAME, APP_VERSION, DEPENDENCIES);
+            output::libs::libs(cli::libs::get(&matches)?);
         }
         ("term", Some(matches)) => {
-            let cli::Term = cli::get_term(matches)?;
-            output::term::term()?;
+            output::term::term(cli::term::get(matches)?)?;
         }
         ("print", Some(matches)) => {
-            let cli::Print {
-                color: (color, _),
-                bg_color,
-                mut text,
-                bold,
-                italic,
-                underline,
-                no_newline,
-            } = cli::get_print(matches)?;
-
-            if !no_newline {
-                text.push('\n');
-            }
-            output::print::print(
-                color.to_rgb(),
-                bg_color.map(|(c, _)| c.to_rgb()),
-                text,
-                italic,
-                bold,
-                underline,
-            )?;
+            output::print::print(cli::print::get(matches)?)?;
         }
         ("show", Some(matches)) => {
-            let cli::Show {
-                colors,
-                output,
-                size,
-            } = cli::get_show(&matches)?;
-
-            println!();
-            for (color, input) in colors {
-                output::show::show(color, input, output, size)?;
-            }
+            output::show::show(cli::show::get(&matches)?)?;
         }
         ("list", Some(matches)) => {
-            let cli::List = cli::get_list(&matches)?;
-
-            html::show_all()?;
+            output::list::list(cli::list::get(&matches)?)?;
         }
         _ => {
             cli::app().print_help().unwrap();

--- a/src/output/libs.rs
+++ b/src/output/libs.rs
@@ -1,0 +1,5 @@
+use crate::cli::{libs::Libs, APP_NAME, APP_VERSION, DEPENDENCIES};
+
+pub fn libs(_: Libs) {
+    println!("{} v{}\n{}", APP_NAME, APP_VERSION, DEPENDENCIES);
+}

--- a/src/output/list.rs
+++ b/src/output/list.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use color_space::Rgb;
+use colored::{Color::TrueColor, Colorize};
+use std::io::{stdout, Write};
+
+use crate::cli::list::List;
+use crate::color::{html::HTML_COLOR_NAMES, space, Color};
+
+const WHITE: colored::Color = TrueColor {
+    r: 255,
+    g: 255,
+    b: 255,
+};
+const BLACK: colored::Color = TrueColor { r: 0, g: 0, b: 0 };
+
+pub fn list(_: List) -> Result<()> {
+    let mut stdout = stdout();
+
+    let mut even = false;
+
+    for &(name, color) in HTML_COLOR_NAMES {
+        if name == "magenta" || name == "aqua" || name.ends_with("grey") {
+            continue;
+        }
+        let rgb = Rgb::from_hex(color);
+        let lab: space::Lab = rgb.into();
+
+        let color = Color::Rgb(rgb).to_term_color();
+
+        let lab_distance = (lab.a.abs().powi(2) + lab.b.abs().powi(2)).sqrt();
+        let colorfulness = lab_distance.min(100.0) / 12.0; // empirically determined values
+        let text_color = if lab.l < (60.0 - colorfulness) {
+            WHITE
+        } else {
+            BLACK
+        };
+        let name = format!(" {}{}", name, &"                      "[name.len()..]);
+        write!(stdout, "{}", name.color(text_color).on_color(color))?;
+        if even {
+            writeln!(stdout)?;
+        }
+        even = !even;
+    }
+    writeln!(stdout)?;
+
+    Ok(())
+}

--- a/src/output/list.rs
+++ b/src/output/list.rs
@@ -4,8 +4,8 @@ use color_space::Rgb;
 use colored::{Color::TrueColor, Colorize};
 use std::io::{stdout, Write};
 
-use crate::cli::list::List;
-use crate::color::{html::HTML_COLOR_NAMES, space, Color};
+use crate::color::{html::HTML_COLOR_NAMES, Color};
+use crate::{cli::list::List, color::TextColor};
 
 const WHITE: colored::Color = TrueColor {
     r: 255,
@@ -31,20 +31,15 @@ pub fn list(_: List) -> Result<()> {
             continue;
         }
 
-        let rgb = Rgb::from_hex(color);
-        let lab: space::Lab = rgb.into();
-
-        let color = Color::Rgb(rgb).to_term_color();
-
-        let lab_distance = (lab.a.abs().powi(2) + lab.b.abs().powi(2)).sqrt();
-        let colorfulness = lab_distance.min(100.0) / 12.0; // empirically determined values
-        let text_color = if lab.l < (60.0 - colorfulness) {
-            WHITE
-        } else {
-            BLACK
+        let color = Color::Rgb(Rgb::from_hex(color));
+        let term_color = color.to_term_color();
+        let text_color = match color.text_color() {
+            TextColor::Black => BLACK,
+            TextColor::White => WHITE,
         };
+
         let name = format!(" {}{}", name, &"                      "[name.len()..]);
-        write!(stdout, "{}", name.color(text_color).on_color(color))?;
+        write!(stdout, "{}", name.color(text_color).on_color(term_color))?;
         if even {
             writeln!(stdout)?;
         }

--- a/src/output/list.rs
+++ b/src/output/list.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use atty::Stream;
 use color_space::Rgb;
 use colored::{Color::TrueColor, Colorize};
 use std::io::{stdout, Write};
@@ -18,10 +19,18 @@ pub fn list(_: List) -> Result<()> {
 
     let mut even = false;
 
+    let is_atty = atty::is(Stream::Stdout);
+
     for &(name, color) in HTML_COLOR_NAMES {
         if name == "magenta" || name == "aqua" || name.ends_with("grey") {
             continue;
         }
+
+        if !is_atty {
+            writeln!(stdout, "{}", name)?;
+            continue;
+        }
+
         let rgb = Rgb::from_hex(color);
         let lab: space::Lab = rgb.into();
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,5 @@
+pub mod libs;
+pub mod list;
 pub mod print;
 pub mod show;
 pub mod term;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,3 @@
+pub mod print;
+pub mod show;
+pub mod term;

--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -2,26 +2,25 @@ use anyhow::Result;
 use colored::Colorize;
 use std::io::{stdout, Write};
 
-use crate::color::space;
+use crate::cli::print::Print;
 
 pub fn print(
-    rgb: space::Rgb,
-    bg: Option<space::Rgb>,
-    text: String,
-    italic: bool,
-    bold: bool,
-    underline: bool,
+    Print {
+        color: (color, _),
+        bg_color,
+        mut text,
+        bold,
+        italic,
+        underline,
+        no_newline,
+    }: Print,
 ) -> Result<()> {
-    let fg = colored::Color::TrueColor {
-        r: rgb.r.round() as u8,
-        g: rgb.g.round() as u8,
-        b: rgb.b.round() as u8,
-    };
-    let bg = bg.map(|c| colored::Color::TrueColor {
-        r: c.r.round() as u8,
-        g: c.g.round() as u8,
-        b: c.b.round() as u8,
-    });
+    if !no_newline {
+        text.push('\n');
+    }
+
+    let fg = color.to_term_color();
+    let bg = bg_color.map(|(c, _)| c.to_term_color());
     let mut text = text.color(fg);
 
     if italic {

--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use colored::Colorize;
+use std::io::{stdout, Write};
+
+use crate::color::space;
+
+pub fn print(
+    rgb: space::Rgb,
+    bg: Option<space::Rgb>,
+    text: String,
+    italic: bool,
+    bold: bool,
+    underline: bool,
+) -> Result<()> {
+    let fg = colored::Color::TrueColor {
+        r: rgb.r.round() as u8,
+        g: rgb.g.round() as u8,
+        b: rgb.b.round() as u8,
+    };
+    let bg = bg.map(|c| colored::Color::TrueColor {
+        r: c.r.round() as u8,
+        g: c.g.round() as u8,
+        b: c.b.round() as u8,
+    });
+    let mut text = text.color(fg);
+
+    if italic {
+        text = text.italic();
+    }
+    if bold {
+        text = text.bold();
+    }
+    if underline {
+        text = text.underline();
+    }
+    if let Some(bg) = bg {
+        text = text.on_color(bg);
+    }
+
+    let mut stdout = stdout();
+    write!(stdout, "{}", text)?;
+    Ok(())
+}

--- a/src/output/show.rs
+++ b/src/output/show.rs
@@ -15,17 +15,21 @@ pub fn show(
         size,
     }: Show,
 ) -> Result<()> {
+    let interactive = atty::is(Stream::Stdout);
     let mut stdout = stdout();
-    writeln!(stdout)?;
 
+    if interactive {
+        writeln!(stdout)?;
+    }
     for (color, input) in colors {
-        show_color(&mut stdout, color, input, output, size)?;
+        show_color(interactive, &mut stdout, color, input, output, size)?;
     }
     Ok(())
 }
 
 /// Print a colored square
 fn show_color(
+    interactive: bool,
     stdout: &mut Stdout,
     color: Color,
     _input: ColorFormat,
@@ -39,7 +43,7 @@ fn show_color(
         b: rgb.b.round() as u8,
     };
 
-    if atty::isnt(Stream::Stdout) {
+    if !interactive {
         let color = output
             .format(color)
             .or_else(|| ColorFormat::Hex.format(color))

--- a/src/output/show.rs
+++ b/src/output/show.rs
@@ -7,7 +7,7 @@ use std::{
     iter,
 };
 
-use crate::color::{format, space, Color, ColorFormat};
+use crate::color::{format, Color, ColorFormat};
 
 /// Print a colored square
 pub fn show(color: Color, _input: ColorFormat, output: ColorFormat, size: u32) -> Result<()> {
@@ -115,44 +115,6 @@ where
         }
         writeln!(stdout)?;
     }
-    Ok(())
-}
-
-pub fn show_text(
-    rgb: space::Rgb,
-    bg: Option<space::Rgb>,
-    text: String,
-    italic: bool,
-    bold: bool,
-    underline: bool,
-) -> Result<()> {
-    let fg = colored::Color::TrueColor {
-        r: rgb.r.round() as u8,
-        g: rgb.g.round() as u8,
-        b: rgb.b.round() as u8,
-    };
-    let bg = bg.map(|c| colored::Color::TrueColor {
-        r: c.r.round() as u8,
-        g: c.g.round() as u8,
-        b: c.b.round() as u8,
-    });
-    let mut text = text.color(fg);
-
-    if italic {
-        text = text.italic();
-    }
-    if bold {
-        text = text.bold();
-    }
-    if underline {
-        text = text.underline();
-    }
-    if let Some(bg) = bg {
-        text = text.on_color(bg);
-    }
-
-    let mut stdout = stdout();
-    write!(stdout, "{}", text)?;
     Ok(())
 }
 

--- a/src/output/show.rs
+++ b/src/output/show.rs
@@ -39,7 +39,7 @@ fn show_color(
         b: rgb.b.round() as u8,
     };
 
-    if !atty::is(Stream::Stdout) {
+    if atty::isnt(Stream::Stdout) {
         let color = output
             .format(color)
             .or_else(|| ColorFormat::Hex.format(color))

--- a/src/output/term.rs
+++ b/src/output/term.rs
@@ -1,8 +1,10 @@
-use crate::color::ansi::{AnsiColor, Bg, Fg, ResetBg, ResetFg};
 use anyhow::Result;
 use std::io::{stdout, Stdout, Write};
 
-pub fn term() -> Result<()> {
+use crate::cli::term::Term;
+use crate::color::ansi::{AnsiColor, Bg, Fg, ResetBg, ResetFg};
+
+pub fn term(_: Term) -> Result<()> {
     let mut stdout = stdout();
 
     let colors = &[

--- a/src/output/term.rs
+++ b/src/output/term.rs
@@ -2,7 +2,7 @@ use crate::color::ansi::{AnsiColor, Bg, Fg, ResetBg, ResetFg};
 use anyhow::Result;
 use std::io::{stdout, Stdout, Write};
 
-pub fn show_term_colors() -> Result<()> {
+pub fn term() -> Result<()> {
     let mut stdout = stdout();
 
     let colors = &[


### PR DESCRIPTION
Examples:

```fish
echo orange blue | colo s
echo Hello world | colo print orange
```

Also fixes `colo list` when not used in a terminal.

Closes #8 