### PR TITLE
Implement `filter` WIP, using logos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "beef"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +71,7 @@ dependencies = [
  "colored",
  "console",
  "fastrand",
+ "logos",
  "strsim 0.10.0",
  "thiserror",
 ]
@@ -118,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +159,30 @@ name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+
+[[package]]
+name = "logos"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91c49573597a5d6c094f9031617bb1fed15c0db68c81e6546d313414ce107e4"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797b1f8a0571b331c1b47e7db245af3dc634838da7a92b3bef4e30376ae1c347"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+ "utf8-ranges",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -264,6 +301,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1"
 strsim = "0.10"
 fastrand = "1.4"
 console = "0.13"
+logos = "0.11"
 
 [dependencies.clap]
 version = "2"

--- a/src/cli/filter.rs
+++ b/src/cli/filter.rs
@@ -1,0 +1,284 @@
+use std::{fmt, iter};
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::{App, Arg, SubCommand};
+
+use crate::{
+    color::{space::*, Color, ColorFormat, ColorSpace},
+    terminal::stdin,
+    State,
+};
+
+use super::{parse::parse_filter, util, Cmd, Show};
+
+#[derive(Debug)]
+pub struct Filter {
+    pub show: Show,
+    pub filters: FilterList,
+}
+
+#[derive(Debug)]
+pub struct FilterList {
+    pub(super) items: Vec<(FilterKey, FilterValue)>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum FilterKey {
+    Brightness,
+    Contrast,
+    Grayscale,
+    HueRotate,
+    Invert,
+    Saturate,
+    Sepia,
+    Other(ColorSpace, String),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum FilterValue {
+    Add(f64),
+    Mul(f64),
+    Div(f64),
+    Set(f64),
+}
+
+impl FilterValue {
+    fn get_add(&self) -> Result<f64> {
+        match *self {
+            FilterValue::Add(n) => Ok(n),
+            _ => bail!("Unsupported value `{}`", self),
+        }
+    }
+
+    fn apply(&self, num: f64) -> f64 {
+        match *self {
+            FilterValue::Add(n) => num + n,
+            FilterValue::Mul(n) => num * n,
+            FilterValue::Div(n) => num / n,
+            FilterValue::Set(n) => n,
+        }
+    }
+}
+
+impl fmt::Display for FilterValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            FilterValue::Add(n) => write!(f, "{}", n),
+            FilterValue::Mul(n) => write!(f, "* {}", n),
+            FilterValue::Div(n) => write!(f, "/ {}", n),
+            FilterValue::Set(n) => write!(f, "= {}", n),
+        }
+    }
+}
+
+const FILTER_HELP_MESSAGE: &str = "\
+A list of filters, for example:
+
+colo filter brightness -10%, hue-rotate 30 -- orange
+
+Available filters are:
+* brightness
+* contrast
+* grayscale
+* hue-rotate
+* invert
+* saturate
+* sepia
+* color components:
+   * r, g, b
+   * h, s, l
+   * when specifying other components,
+     the color space is needed, e.g. `cmy:c`
+
+Color components are relative, unless prefixed with `=`, e.g.
+
+colo filter r=10 g+50 lab:l-20 -- orange
+ ";
+
+const COLOR_HELP_MESSAGE: &str = "\
+The input colors. Multiple colors can be specified. Supported formats:
+
+* HTML color name, e.g. 'rebeccapurple'
+* Hexadecimal RGB color, e.g. '07F', '0077FF'
+* Color components, e.g. 'hsl(30, 100%, 50%)'
+  Commas and parentheses are optional.
+  For supported color spaces, see <https://aloso.github.io/colo/color_spaces>
+
+If colo is used behind a pipe or outside of a terminal, the colors can be provided via stdin, e.g.
+
+$ echo orange blue FF7700 | colo filter contrast 30%";
+
+impl Cmd for Filter {
+    fn command<'a, 'b>(state: State) -> App<'a, 'b> {
+        SubCommand::with_name("filter")
+            .about("Apply filters to the color(s)")
+            .visible_alias("f")
+            .args(&[
+                Arg::with_name("filters")
+                    .index(1)
+                    .takes_value(true)
+                    .multiple(true)
+                    .required(true)
+                    .allow_hyphen_values(true)
+                    .help(FILTER_HELP_MESSAGE),
+                Arg::with_name("colors")
+                    .takes_value(true)
+                    .index(2)
+                    .last(true)
+                    .required(state.interactive)
+                    .multiple(true)
+                    .use_delimiter(false)
+                    .help(COLOR_HELP_MESSAGE),
+                Arg::with_name("output-format")
+                    .long("out")
+                    .short("o")
+                    .takes_value(true)
+                    .possible_values(super::COLOR_FORMATS)
+                    .hide_possible_values(true)
+                    .case_insensitive(true)
+                    .help(
+                        "Output format (html, hex, or color space) [possible values: rgb, cmy, \
+                        cmyk, hsv, hsl, lch, luv, lab, hunterlab, xyz, yxy, gry, hex, html]",
+                    ),
+                Arg::with_name("size")
+                    .long("size")
+                    .short("s")
+                    .takes_value(true)
+                    .default_value("4")
+                    .help("Size of the color square in terminal rows"),
+            ])
+    }
+
+    fn parse(matches: &clap::ArgMatches, &mut state: &mut State) -> Result<Self> {
+        let mut colors = match matches.values_of("colors") {
+            Some(values) => util::values_to_colors(values, state)?,
+            None => vec![],
+        };
+        if !state.interactive && colors.is_empty() {
+            let text = stdin::read_all()?;
+            colors = util::values_to_colors(iter::once(text.as_str()), state)?;
+        }
+
+        let filters = matches
+            .values_of("filters")
+            .ok_or_else(|| anyhow!("Filters not present"))?
+            .flat_map(|s| iter::once(s).chain(iter::once(" ")))
+            .collect::<String>();
+
+        let filters = parse_filter(&filters)?;
+
+        let size = matches
+            .value_of("size")
+            .map(util::parse_size)
+            .unwrap_or(Ok(4))?;
+
+        let output = util::get_color_format(&matches, "output-format")?;
+
+        let show = Show {
+            colors,
+            size,
+            output,
+        };
+        Ok(Self { show, filters })
+    }
+
+    fn run(&self, state: State) -> Result<()> {
+        let mut show = self.show.clone();
+
+        for (key, value) in &self.filters.items {
+            match *key {
+                FilterKey::Brightness => {
+                    for (color, fmt) in &mut show.colors {
+                        brightness(color, fmt, value)?;
+                    }
+                }
+                FilterKey::Contrast => {
+                    bail!("`contrast` is not yet implemented");
+                }
+                FilterKey::Grayscale => {
+                    bail!("`grayscale` is not yet implemented");
+                }
+                FilterKey::HueRotate => {
+                    for (color, fmt) in &mut show.colors {
+                        hue_rotate(color, fmt, value)?;
+                    }
+                }
+                FilterKey::Invert => {
+                    for (color, fmt) in &mut show.colors {
+                        invert(color, fmt, value)?;
+                    }
+                }
+                FilterKey::Saturate => {
+                    bail!("`saturate` is not yet implemented");
+                }
+                FilterKey::Sepia => {
+                    bail!("`sepia` is not yet implemented");
+                }
+                FilterKey::Other(s, ref comp) => {
+                    for (color, fmt) in &mut show.colors {
+                        other(color, fmt, value, s, comp)?;
+                    }
+                }
+            }
+        }
+
+        show.run(state)
+    }
+}
+
+fn brightness(color: &mut Color, fmt: &mut ColorFormat, value: &FilterValue) -> Result<()> {
+    fn br(component: f64, amount: f64) -> f64 {
+        (component * amount).min(255.0)
+    }
+
+    let amount = value.get_add().context("Invalid `invert` value")?;
+
+    let Rgb { r, g, b } = (*color).into();
+    let rgb = Rgb::new(br(r, amount), br(g, amount), br(b, amount));
+    *color = Color::Rgb(rgb);
+    *fmt = ColorFormat::Normal(ColorSpace::Rgb);
+    Ok(())
+}
+
+fn hue_rotate(color: &mut Color, fmt: &mut ColorFormat, value: &FilterValue) -> Result<()> {
+    let amount = value.get_add().context("Invalid `hue-rotate` value")?;
+
+    let Hsl { h, s, l } = (*color).into();
+    let hsl = Hsl::new((h + amount).rem_euclid(360.0), s, l);
+    *color = Color::Hsl(hsl);
+    *fmt = ColorFormat::Normal(ColorSpace::Hsl);
+    Ok(())
+}
+
+fn invert(color: &mut Color, fmt: &mut ColorFormat, value: &FilterValue) -> Result<()> {
+    fn inv(component: f64, amount: f64) -> f64 {
+        let diff = 255.0 - component * 2.0;
+        component + diff * amount
+    }
+
+    let amount = value.get_add().context("Invalid `invert` value")?;
+
+    let Rgb { r, g, b } = (*color).into();
+    let rgb = Rgb::new(inv(r, amount), inv(g, amount), inv(b, amount));
+    *color = Color::Rgb(rgb);
+    *fmt = ColorFormat::Normal(ColorSpace::Rgb);
+    Ok(())
+}
+
+fn other(
+    color: &mut Color,
+    fmt: &mut ColorFormat,
+    value: &FilterValue,
+    s: ColorSpace,
+    comp: &str,
+) -> Result<()> {
+    let mut new_color = color.to_color_space(s);
+    let c = new_color
+        .get_component(comp)
+        .with_context(|| anyhow!("Component {} doesn't exist in the {} color space", comp, s))?;
+    *c = value.apply(*c);
+
+    *color = new_color;
+    *fmt = ColorFormat::Normal(s);
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,10 +4,12 @@ use clap::{App, AppSettings, Arg, ArgMatches};
 use crate::State;
 
 mod contrast;
+mod filter;
 mod gradient;
 mod libs;
 mod list;
 mod mix;
+mod parse;
 mod pick;
 mod print;
 mod show;
@@ -15,6 +17,7 @@ mod term;
 mod textcolor;
 
 pub(crate) use contrast::Contrast;
+pub(crate) use filter::Filter;
 pub(crate) use gradient::Gradient;
 pub(crate) use libs::Libs;
 pub(crate) use list::List;
@@ -104,6 +107,7 @@ impl Cmd for MainCmd {
             .author("Ludwig Stecher <ludwig.stecher@gmx.de>")
             .about("Manages colors in various color spaces.")
             .subcommand(Show::command(state))
+            .subcommand(Filter::command(state))
             .subcommand(Print::command(state))
             .subcommand(Pick::command(state))
             .subcommand(Term::command(state))
@@ -143,6 +147,7 @@ impl Cmd for MainCmd {
 
         let subcommand: Box<dyn Cmd> = match matches.subcommand() {
             ("show", Some(matches)) => Box::new(Show::parse(matches, state)?),
+            ("filter", Some(matches)) => Box::new(Filter::parse(matches, state)?),
             ("libs", Some(matches)) => Box::new(Libs::parse(matches, state)?),
             ("term", Some(matches)) => Box::new(Term::parse(matches, state)?),
             ("print", Some(matches)) => Box::new(Print::parse(matches, state)?),

--- a/src/cli/parse/filter.rs
+++ b/src/cli/parse/filter.rs
@@ -1,0 +1,235 @@
+use anyhow::{bail, Result};
+use logos::Logos;
+
+use super::super::filter::{FilterKey, FilterList, FilterValue};
+use crate::color::ColorSpace;
+
+#[derive(Logos, Debug, PartialEq)]
+enum Token<'a> {
+    #[token("brightness", |_| FilterKey::Brightness)]
+    #[token("contrast", |_| FilterKey::Contrast)]
+    #[token("grayscale", |_| FilterKey::Grayscale)]
+    #[token("greyscale", |_| FilterKey::Grayscale)]
+    #[token("hue-rotate", |_| FilterKey::HueRotate)]
+    #[token("rotate", |_| FilterKey::HueRotate)]
+    #[token("invert", |_| FilterKey::Invert)]
+    #[token("saturate", |_| FilterKey::Saturate)]
+    #[token("sepia", |_| FilterKey::Sepia)]
+    CssFilter(FilterKey),
+
+    #[token("rgb:", |_| ColorSpace::Rgb)]
+    #[token("cmy:", |_| ColorSpace::Cmy)]
+    #[token("cmyk:", |_| ColorSpace::Cmyk)]
+    #[token("hsl:", |_| ColorSpace::Hsl)]
+    #[token("hsv:", |_| ColorSpace::Hsv)]
+    #[token("lab:", |_| ColorSpace::Lab)]
+    #[token("lch:", |_| ColorSpace::Lch)]
+    #[token("luv:", |_| ColorSpace::Luv)]
+    #[token("hunterlab:", |_| ColorSpace::HunterLab)]
+    #[token("xyz:", |_| ColorSpace::Xyz)]
+    #[token("yxy:", |_| ColorSpace::Yxy)]
+    #[token("gry:", |_| ColorSpace::Gray)]
+    ColorSpace(ColorSpace),
+
+    #[regex(r"[a-zA-Z]\w*")]
+    ColorComponent(&'a str),
+
+    #[regex(r"[0-9]*\.[0-9]+", |lex| lex.slice().parse())]
+    #[regex(r"[0-9]+", |lex| lex.slice().parse())]
+    Value(f64),
+
+    #[token("=", |_| Modifier::Set)]
+    #[token("+", |_| Modifier::Add)]
+    #[token("-", |_| Modifier::Sub)]
+    #[token("\\-", |_| Modifier::Sub)]
+    #[token("*", |_| Modifier::Mul)]
+    #[token("/", |_| Modifier::Div)]
+    Modifier(Modifier),
+
+    #[token("%")]
+    Percent,
+
+    #[token(",")]
+    Comma,
+
+    #[token("(")]
+    OpenParen,
+
+    #[token(")")]
+    CloseParen,
+
+    #[error]
+    #[regex(r"[ \t\n\f]+", logos::skip)]
+    Error,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Modifier {
+    Set,
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+enum State {
+    Start {
+        allow_comma: bool,
+    },
+    ColorSpace(ColorSpace),
+    Key {
+        key: FilterKey,
+        paren: bool,
+    },
+    Modifier {
+        key: FilterKey,
+        m: Modifier,
+        paren: bool,
+    },
+    Value {
+        key: FilterKey,
+        value: FilterValue,
+        paren: bool,
+        percent: bool,
+    },
+}
+
+pub fn parse_filter(input: &str) -> Result<FilterList> {
+    let mut items = Vec::new();
+    let mut state = State::Start { allow_comma: false };
+    let mut lex = Token::lexer(input);
+
+    while let Some(token) = lex.next() {
+        state = match state {
+            State::Start { allow_comma } => match token {
+                Token::CssFilter(key) => State::Key { key, paren: false },
+                Token::ColorSpace(s) => State::ColorSpace(s),
+                Token::Comma if allow_comma => State::Start { allow_comma: false },
+                Token::ColorComponent(c) => {
+                    let s = match c {
+                        "r" | "g" | "b" => ColorSpace::Rgb,
+                        "h" | "s" | "l" => ColorSpace::Hsl,
+                        _ => bail!("Unknown color component {:?}", c),
+                    };
+                    State::Key {
+                        key: FilterKey::Other(s, c.into()),
+                        paren: false,
+                    }
+                }
+                _ => bail!("Expected filter, got {:?}", lex.slice()),
+            },
+            State::ColorSpace(s) => match token {
+                Token::ColorComponent(c) => State::Key {
+                    key: FilterKey::Other(s, c.into()),
+                    paren: false,
+                },
+                _ => bail!("Expected color component, got {:?}", lex.slice()),
+            },
+            State::Key { key, paren } => match token {
+                Token::Value(v) => State::Value {
+                    key,
+                    value: FilterValue::Add(v),
+                    paren,
+                    percent: false,
+                },
+                Token::Modifier(m) => State::Modifier { key, m, paren },
+                Token::OpenParen if !paren => State::Key { key, paren: true },
+                _ => bail!("Expected value or operator, got {:?}", lex.slice()),
+            },
+            State::Modifier { key, m, paren } => match token {
+                Token::Value(v) => {
+                    let value = match m {
+                        Modifier::Set => FilterValue::Set(v),
+                        Modifier::Add => FilterValue::Add(v),
+                        Modifier::Sub => FilterValue::Add(-v),
+                        Modifier::Mul => FilterValue::Mul(v),
+                        Modifier::Div => FilterValue::Div(v),
+                    };
+                    State::Value {
+                        key,
+                        value,
+                        paren,
+                        percent: false,
+                    }
+                }
+                _ => bail!("Expected value, got {:?}", lex.slice()),
+            },
+            State::Value {
+                key,
+                value,
+                paren,
+                percent,
+            } => match token {
+                Token::CssFilter(f) if !paren => {
+                    items.push((key, value));
+                    State::Key {
+                        key: f,
+                        paren: false,
+                    }
+                }
+                Token::ColorSpace(s) if !paren => {
+                    items.push((key, value));
+                    State::ColorSpace(s)
+                }
+                Token::Comma if !paren => {
+                    items.push((key, value));
+                    State::Start { allow_comma: false }
+                }
+                Token::CssFilter(_) | Token::ColorSpace(_) | Token::Comma => {
+                    bail!("Expected `)`, got {:?}", lex.slice());
+                }
+                Token::ColorComponent(c) => {
+                    items.push((key, value));
+                    let s = match c {
+                        "r" | "g" | "b" => ColorSpace::Rgb,
+                        "h" | "s" | "l" => ColorSpace::Hsl,
+                        _ => bail!("Unknown color component {:?}", c),
+                    };
+                    State::Key {
+                        key: FilterKey::Other(s, c.into()),
+                        paren: false,
+                    }
+                }
+                Token::CloseParen if paren => {
+                    items.push((key, value));
+                    State::Start { allow_comma: true }
+                }
+                Token::Percent if !percent => State::Value {
+                    key,
+                    value: match value {
+                        FilterValue::Add(n) => FilterValue::Add(n / 100.0),
+                        FilterValue::Mul(n) => FilterValue::Mul(n / 100.0),
+                        FilterValue::Div(n) => FilterValue::Div(n / 100.0),
+                        FilterValue::Set(n) => FilterValue::Set(n / 100.0),
+                    },
+                    paren,
+                    percent: true,
+                },
+                _ => bail!("Expected filter, got {:?}", lex.slice()),
+            },
+        };
+    }
+
+    match state {
+        State::Start { allow_comma: false } => {
+            bail!("Unexpected trailing comma")
+        }
+        State::ColorSpace(_) => {
+            bail!("Expected color component, got EOF")
+        }
+        State::Key { .. } | State::Modifier { .. } => {
+            bail!("Expected value, got EOF")
+        }
+        State::Value {
+            key, value, paren, ..
+        } => {
+            if paren {
+                bail!("Unclosed parenthesis");
+            }
+            items.push((key, value));
+        }
+        _ => {}
+    }
+
+    Ok(FilterList { items })
+}

--- a/src/cli/parse/mod.rs
+++ b/src/cli/parse/mod.rs
@@ -1,0 +1,3 @@
+mod filter;
+
+pub use filter::parse_filter;

--- a/src/cli/pick.rs
+++ b/src/cli/pick.rs
@@ -59,7 +59,7 @@ impl Cmd for Pick {
             .value_of("size")
             .map(util::parse_size)
             .unwrap_or(Ok(4))?;
-        let output = util::get_color_format(&matches, "output-format")?.unwrap_or_default();
+        let output = util::get_color_format(&matches, "output-format")?;
 
         let (color, cs) = get_color_options(matches, state)?;
         let cs = get_color_space_option(matches).or(cs);

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -22,9 +22,10 @@ If colo is used behind a pipe or outside of a terminal, the colors can be provid
 $ echo orange blue FF7700 | colo show";
 
 /// The `show`/`s` subcommand
+#[derive(Debug, Clone)]
 pub struct Show {
     pub colors: Vec<(Color, ColorFormat)>,
-    pub output: ColorFormat,
+    pub output: Option<ColorFormat>,
     pub size: u32,
 }
 
@@ -76,17 +77,15 @@ impl Cmd for Show {
             colors = color::parse(&input, state)?;
         }
 
-        let output = util::get_color_format(&matches, "output-format")?
-            .or_else(|| {
-                if colors.is_empty() {
-                    None
-                } else if colors.windows(2).all(|c| c[0].1 == c[1].1) {
-                    Some(colors[0].1).filter(|&c| c != ColorFormat::Html)
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_default();
+        let output = util::get_color_format(&matches, "output-format")?.or_else(|| {
+            if colors.is_empty() {
+                None
+            } else if colors.windows(2).all(|c| c[0].1 == c[1].1) {
+                Some(colors[0].1).filter(|&c| c != ColorFormat::Html)
+            } else {
+                None
+            }
+        });
 
         Ok(Show {
             colors,
@@ -99,7 +98,7 @@ impl Cmd for Show {
         terminal::show_colors(
             state,
             self.colors.iter().map(|&(c, _)| c),
-            self.output,
+            self.output.unwrap_or_default(),
             self.size,
         )
     }

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -87,6 +87,82 @@ impl Color {
         }
     }
 
+    pub fn get_component(&mut self, name: &str) -> Option<&mut f64> {
+        Some(match self {
+            Color::Rgb(n) => match name {
+                "r" => &mut n.r,
+                "g" => &mut n.g,
+                "b" => &mut n.b,
+                _ => return None,
+            },
+            Color::Cmy(n) => match name {
+                "c" => &mut n.c,
+                "m" => &mut n.m,
+                "y" => &mut n.y,
+                _ => return None,
+            },
+            Color::Cmyk(n) => match name {
+                "c" => &mut n.c,
+                "m" => &mut n.m,
+                "y" => &mut n.y,
+                "k" => &mut n.k,
+                _ => return None,
+            },
+            Color::Hsv(n) => match name {
+                "h" => &mut n.h,
+                "s" => &mut n.s,
+                "v" => &mut n.v,
+                _ => return None,
+            },
+            Color::Hsl(n) => match name {
+                "h" => &mut n.h,
+                "s" => &mut n.s,
+                "l" => &mut n.l,
+                _ => return None,
+            },
+            Color::Lch(n) => match name {
+                "l" => &mut n.l,
+                "c" => &mut n.c,
+                "h" => &mut n.h,
+                _ => return None,
+            },
+            Color::Luv(n) => match name {
+                "l" => &mut n.l,
+                "u" => &mut n.u,
+                "v" => &mut n.v,
+                _ => return None,
+            },
+            Color::Lab(n) => match name {
+                "l" => &mut n.l,
+                "a" => &mut n.a,
+                "b" => &mut n.b,
+                _ => return None,
+            },
+            Color::HunterLab(n) => match name {
+                "l" => &mut n.l,
+                "a" => &mut n.a,
+                "b" => &mut n.b,
+                _ => return None,
+            },
+            Color::Xyz(n) => match name {
+                "x" => &mut n.x,
+                "y" => &mut n.y,
+                "z" => &mut n.z,
+                _ => return None,
+            },
+            Color::Yxy(n) => match name {
+                "y1" => &mut n.y1,
+                "x" => &mut n.x,
+                "y2" => &mut n.y2,
+                _ => return None,
+            },
+            Color::Gray(n) => match name {
+                "l" => &mut n.l,
+                _ => return None,
+            },
+        })
+    }
+
     /// Converts the color to a different color space. It is in the same color
     /// space, this is a no-op.
     pub fn to_color_space(&self, color_space: ColorSpace) -> Self {


### PR DESCRIPTION
Closes #12 

Adds a `filter` subcommand (`f` for short) with advanced color editing capabilities. `filter` expects a list of instructions. Each instruction is either a CSS filter or a color component instruction.

Available CSS filters are:

* [x] brightness
* [ ] contrast
* [ ] grayscale
* [x] hue-rotate
* [x] invert
* [ ] saturate
* [ ] sepia

These filters work exactly the same as in the [CSS `filter` property](https://developer.mozilla.org/en-US/docs/Web/CSS/filter). For example, `brightness 120%` will increase the brightness by 20%. Note that most CSS filters use simple algorithms in the RGB color space, and may produce inadequate results. For better results, modify the color components directly in a suitable color space.

Color components are specified with the syntax `<color_space>:<component>`. For example, `hsl:s` specifies the _saturation_ component in the HSL color space. For RGB and HSL, the color space is optional, i.e. `r` is equivalent to `rgb:r`, `l` is equivalent to `hsl:l`, and so on.

Each CSS filter name or color component is followed by a number. This number can be negative, and it can be written in percent. For color components, the value can be preceded my an _operator_, which is one of

* `*` for multiplication (this must be escaped in some shells)
* `/` for division
* `=` to replace the value

### Examples

```fish
# set the red component to 50, increase brightness by 20% and increase the HSV saturation component by 0.3
colo filter r=50, brightness 120%, hsv:s 0.3  -- orange blue 15A

# the above is equivalent to this:
colo filter "r = 50 brightness(120%) hsv:s+0.3"  -- orange blue 15A
```

As you can see, the format is whitespace insensitive and ignores commas. Values can optionally be wrapped in parentheses, to be fully compatible with the CSS syntax.